### PR TITLE
Add a guideline about managing access to objects (IDOR)

### DIFF
--- a/docs/security_guidelines.md
+++ b/docs/security_guidelines.md
@@ -220,3 +220,18 @@ Implementing a code review process helps catch potential security issues before 
 ### Lock down your server configuration
 
 Ensure that configuration files for your web server are not publicly accessible.
+
+### Verify access to objects
+
+Insufficient access control and insecure exposure of object identifiers, such as database keys or file paths can lead to [Insecure Direct Object Reference (IDOR)](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/IDOR) attacks.
+
+To mitigate this:
+
+- Always verify that the authenticated user is authorized to access or modify the object.
+- Avoid exposing predictable, sequential, or sensitive object identifiers (like user IDs or email addresses).
+- Use more complex IDs that are harder to predict (for example, UUIDs).
+
+#### Learn more
+
+- [Insecure Direct Object Reference Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html) (OWASP)
+- [Insecure Direct Object Reference (IDOR)](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/IDOR) (MDN)


### PR DESCRIPTION
I'd like to propose to an add guideline about managing access to objects. Such access should be verified to prevent IDOR attacks.

I think it is more a security practice than a web platform security feature, so I put it in the second section. I will say that I don't understand why this document splits the guidelines in these two buckets (practices and features), and I also don't know if there is any order for the listings, so I just added this proposed guideline at the bottom.