### PR TITLE
Rewrite maintainer authentication guideline

### DIFF
--- a/docs/swag.html
+++ b/docs/swag.html
@@ -291,11 +291,18 @@ When selecting open source libraries, frameworks, build tools, or similar, take 
 
 This helps ensure that the libraries you use are actively maintained and have a good security track record, reducing potential vulnerabilities in your application. Consider the following [Scorecard](https://securityscorecards.dev) metrics: _tbd_
 
-### Require multi-factor authentication for project developers
+### Require strong authentication for project maintainers
 
-Ensure all developers working on the project are using multi-factor authentication (MFA) to access the source repository.
+Supply chain attacks often target project maintainers: by gaining control of a maintainer's account an attacker can introduce malicious code or ship a malicious update of the project.
 
-Multi-factor authentication adds an additional layer of security by requiring more than one form of verification, reducing the risk of unauthorized access to your codebase.
+This means that a project must use a strong authentication method for maintainer accounts. In particular, attackers often use [phishing](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Phishing) to gain control of maintainer accounts, so authentication methods should aim to be phishing-resistant.
+
+Requiring multi-factor authentication for project maintainers makes phishing more difficult but does not prevent it. [Passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) provide the strongest defense against phishing attacks.
+
+#### Learn more
+
+- [Phishing](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Phishing)
+- [Passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys)
 
 ### Have a documented security policy
 

--- a/docs/swag.html
+++ b/docs/swag.html
@@ -297,7 +297,7 @@ Supply chain attacks often target project maintainers: by gaining control of a m
 
 This means that a project must use a strong authentication method for maintainer accounts. In particular, attackers often use [phishing](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Phishing) to gain control of maintainer accounts, so authentication methods should aim to be phishing-resistant.
 
-Requiring multi-factor authentication for project maintainers makes phishing more difficult but does not prevent it. [Passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) provide the strongest defense against phishing attacks.
+Requiring multi-factor authentication for project maintainers makes phishing more difficult but, depending on the authentication methods used, does not always prevent it. [Passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) provide the strongest defense against phishing attacks.
 
 #### Learn more
 


### PR DESCRIPTION
The guidelines currently recommend that project maintainers use MFA. Since most attacks on maintainer accounts are phishing attacks, and we know that many phishing attacks these days defeat the most commonly used forms of MFA, this doesn't seem like a good idea.

I've updated the guideline to be a bit more general, talking about the reason to protect maintainer accounts, the need especially to defend against phishing, the weakness of MFA, and recommending passkeys as the most phishing-resistant method.

