### PR TITLE
Update dependency update guideline

### DIFF
--- a/docs/swag.html
+++ b/docs/swag.html
@@ -333,9 +333,14 @@ To address both these considerations, a software project should:
 - [Configuring Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-security-updates) (GitHub)
 - [Package Managers Need to Cool Down](https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html)
 
-### Keep dependencies up to date
+### Monitor known vulnerabilities in your web app's direct & indirect dependencies
 
-Keeping dependencies (i.e., libraries, polyfills, frameworks, etc.) up to date minimizes the risk of exploitation through known vulnerabilities. Regular updates should be part of your development lifecycle.
+Regularly checking for vulnerabilities in both direct and transitive dependencies helps you stay informed about potential security risks and take action to mitigate them.
+
+#### Learn more
+
+- [Configuring Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-security-updates) (GitHub)
+
 
 ### Do not push secrets to a repository
 

--- a/docs/swag.html
+++ b/docs/swag.html
@@ -323,7 +323,7 @@ If your project uses any third-party dependencies, you need to be able to respon
 
 To address both these considerations, a software project should:
 
-- Use a package manager and a tool such as [Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-security-updates) that can monitor your dependencies for known vulnerabilities and updates.
+- Use a package manager and a tool, such as [Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-security-updates) or [Renovate](https://docs.renovatebot.com/), that can monitor your dependencies for known vulnerabilities and updates.
 - Use a [lockfile](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Supply_chain_attacks#using_a_lockfile) to give you precise control over the versions of your dependencies, and to prevent your build system from automatically updating dependencies.
 - Have a process to review suggested dependency updates, to evaluate the risk/reward of accepting them.
 - Consider enforcing a delay before accepting updates, using settings like Deno's [`minimumDependencyAge`](https://deno.com/blog/v2.6#controlling-dependency-stability): this increases the chances that a malicious update will be discovered before you have accepted it into your own project.

--- a/docs/swag.html
+++ b/docs/swag.html
@@ -314,17 +314,24 @@ Threat modeling helps identify potential security threats and vulnerabilities in
 - Threat modeling guide (soon on MDN)
 - Example threat model (soon on MDN)
 
-### Use package managers such as NPM to automatically manage dependencies and enable updates
+### Control dependency updates
 
-Package managers streamline the process of managing libraries and dependencies, ensuring that you can easily update to the latest versions, which often include important security patches.
+If your project uses any third-party dependencies, you need to be able to respond when updated versions of those packages are released. There are two security considerations here:
 
-### Monitor known vulnerabilities in your web app's direct & indirect dependencies
+- If a vulnerability is found in a dependency, and a fixed version is released, you need to adopt it as soon as possible.
+- If an attacker has compromised the account of one of the dependency's maintainers, and used it to publish a malicious update, you need to avoid adopting it.
 
-Regularly checking for vulnerabilities in both direct and transitive dependencies helps you stay informed about potential security risks and take action to mitigate them.
+To address both these considerations, a software project should:
+
+- Use a package manager and a tool such as [Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-security-updates) that can monitor your dependencies for known vulnerabilities and updates.
+- Use a [lockfile](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Supply_chain_attacks#using_a_lockfile) to give you precise control over the versions of your dependencies, and to prevent your build system from automatically updating dependencies.
+- Have a process to review suggested dependency updates, to evaluate the risk/reward of accepting them.
+- Consider enforcing a delay before accepting updates, using settings like Deno's [`minimumDependencyAge`](https://deno.com/blog/v2.6#controlling-dependency-stability): this increases the chances that a malicious update will be discovered before you have accepted it into your own project.
 
 #### Learn more
 
 - [Configuring Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-security-updates) (GitHub)
+- [Package Managers Need to Cool Down](https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html)
 
 ### Keep dependencies up to date
 


### PR DESCRIPTION
The current guidelines around dependency update don't capture the risks in updating too eagerly. This PR merges two guidelines (2.5 and 2.6) into one, and tries to capture the balance between:

- taking updates that might fix vulnerabilities
- not taking updates that might contain them

There are probably more references we could add here, but this is a start anyway.