### PR TITLE
Add authentication guidelines

### DIFF
--- a/docs/swag.html
+++ b/docs/swag.html
@@ -306,7 +306,7 @@ Implementations should use reputable packages for verifying the assertions that 
 
 - [Passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys)
 
-### Follow good practices for password-based authentication
+### Password-based authentication practices
 
 Passwords have [several well-known security weaknesses](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#weaknesses_of_password-based_authentication), which are commonly exploited by attackers, so we don't recommend that websites offer passwords as an authentication method. If you do need to support them, there are some practices you can follow to minimize the risks:
 
@@ -321,7 +321,7 @@ Passwords can be combined with other authentication methods to make a multi-fact
 
 - [Passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords)
 
-### Follow good practices for OTP authentication
+### OTP authentication practices
 
 A one-time password (OTP) is a code that is specific to a single login attempt. The website generates the code and either sends it to the user in a separate channel, such as an email, or the user's device independently generates the code. The user then enters the code on the site to log in.
 
@@ -332,6 +332,22 @@ If you do use OTP, prefer to use [Time-based OTP (TOTP)](https://developer.mozil
 #### Learn more
 
 - [OTP](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP)
+
+### Session management practices
+
+Implement good practices to remember an authenticated user's identity in your website:
+
+- If your architecture allows it, choose a [centralized](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Session_management#centralized_session_management) session management architecture, in which the user's state is stored in the server, and the client is given an ID for the session, in preference to a [decentralized](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Session_management#decentralized_session_management) architecture, in which the client stores the user's state as a digitally signed token. This is mainly because [it's harder to invalidate a session in a decentralized architecture](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Session_management#invalidating_sessions).
+- Store the session identifier in a cookie. Set its `Secure` and `HttpOnly` attributes, and set the `SameSite` attribute to `Strict` if possible, and otherwise `Lax`.
+- Always generate a new session ID, and invalidate any existing one, whenever the user signs in.
+- Define and implement a policy for session expiry, based on the age of the session and the time since the user was last active.
+- Invalidate the user's session, and make the user reauthenticate, when the user attempts a high-risk operation (such as changing their credentials) or you have some reason to suspect that the session ID might have been stolen.
+- Use a reputable session management framework or library, rather than implementing session management yourself.
+
+#### Learn more
+
+- [Session management](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Session_management) (MDN)
+- [Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html) (OWASP)
 
 ## Operational Practices
 

--- a/docs/swag.html
+++ b/docs/swag.html
@@ -302,6 +302,10 @@ Implementations should use reputable packages for verifying the assertions that 
 - Verify assertion signatures.
 - Verify that the assertion's origin is what the website expects.
 
+#### Learn more
+
+- [Passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys)
+
 ### Follow good practices for password-based authentication
 
 Passwords have [several well-known security weaknesses](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#weaknesses_of_password-based_authentication), which are commonly exploited by attackers, so we don't recommend that websites offer passwords as an authentication method. If you do need to support them, there are some practices you can follow to minimise the risks:
@@ -317,7 +321,6 @@ Passwords can be combined with other authentication methods to make a multi-fact
 
 - [Passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords)
 
-
 ### Follow good practices for OTP authentication
 
 A one-time password (OTP) is a code that is specific to a single login attempt. The website generates the code and either sends it to the user in a separate channel, such as an email, or the user's device independently generates the code. The user then enters the code on the site to log in.
@@ -325,6 +328,10 @@ A one-time password (OTP) is a code that is specific to a single login attempt. 
 OTP authentication is more secure than password-based authentication: it provides a defense against some of the weaknesses of passwords, notably [guessing](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#guessing) and [credential stuffing](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#credential_stuffing). However, it is still vulnerable to phishing attacks.
 
 If you do use OTP, prefer to use [Time-based OTP (TOTP)](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP#totp) in preference to methods which send the code to the user's device via email or SMS. In particular, avoid SMS-based OTP, because it is too easy for attackers to intercept the SMS that contains the code.
+
+#### Learn more
+
+- [OTP](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP)
 
 ## Operational Practices
 

--- a/docs/swag.html
+++ b/docs/swag.html
@@ -283,7 +283,7 @@ Insufficient access control and insecure exposure of object identifiers, such as
 
 ## Authentication guidelines
 
-This section outline guidelines for websites that need to authenticate users.
+This section outlines guidelines for websites that need to authenticate users.
 
 We recommend that websites should use [passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) to authenticate users wherever possible. If you need to support other methods such as [one-time passwords (OTP)](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP) or [passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords), there are practices you can follow to minimise the risks.
 

--- a/docs/swag.html
+++ b/docs/swag.html
@@ -287,19 +287,44 @@ This section outline guidelines for websites that need to authenticate users.
 
 We recommend that websites should use [passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) to authenticate users wherever possible. If you need to support other methods such as [one-time passwords (OTP)](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP) or [passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords), there are practices you can follow to minimise the risks.
 
-### Use passkeys to authenticate users
+### Support passkeys
 
 Websites should support [passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) as an authentication mechanism. If you also support other methods such as passwords, encourage users to prefer passkeys, and enable users to [switch from passwords to passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys#migrating_from_passwords).
 
 Passkeys provide protection against many common attacks on authentication systems, including [phishing](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Phishing) attacks.
 
-### Follow good practices for OTP authentication
+One risk of using passkeys is for users to become locked out of their account if they lose the device that contains their passkeys. Implementations should help protect against this by allowing users to create multiple passkeys on different authenticators, and encouraging users to create passkeys on authenticators that are automatically backed up.
 
-Enable users to use [passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) to authenticate themselves to your site.
+Passkey implementations should allow users to see and edit metadata about the passkeys that they have created, to create new passkeys, and to delete existing passkeys.
+
+Implementations should use reputable packages for verifying the assertions that were generated using passkeys. Implementations must:
+
+- Verify assertion signatures.
+- Verify that the assertion's origin is what the website expects.
 
 ### Follow good practices for password-based authentication
 
-We don't recommend that websites offer passwords as an authentication method,
+Passwords have [several well-known security weaknesses](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#weaknesses_of_password-based_authentication), which are commonly exploited by attackers, so we don't recommend that websites offer passwords as an authentication method. If you do need to support them, there are some practices you can follow to minimise the risks:
+
+- [Ensure that password managers can work with your site.](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#supporting_password_managers)
+- When users create new passwords, [check their strength and reject weak passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#choosing_strong_passwords).
+- Ensure passwords are [transmitted](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#secure_password_transmission) and [stored](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#secure_password_storage) securely.
+- [Implement a secure process for users to change passwords.](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#password_reset)
+
+Passwords can be combined with other authentication methods to make a multi-factor authentication system. Often the additional method is a one-time password, which represents "something the user has" to augment the password's "something the user knows". This type of system is more secure than passwords alone, but although it makes phishing attacks more difficult, [it does not prevent them](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Phishing#multi-factor_authentication).
+
+#### Learn more
+
+- [Passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords)
+
+
+### Follow good practices for OTP authentication
+
+A one-time password (OTP) is a code that is specific to a single login attempt. The website generates the code and either sends it to the user in a separate channel, such as an email, or the user's device independently generates the code. The user then enters the code on the site to log in.
+
+OTP authentication is more secure than password-based authentication: it provides a defense against some of the weaknesses of passwords, notably [guessing](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#guessing) and [credential stuffing](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#credential_stuffing). However, it is still vulnerable to phishing attacks.
+
+If you do use OTP, prefer to use [Time-based OTP (TOTP)](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP#totp) in preference to methods which send the code to the user's device via email or SMS. In particular, avoid SMS-based OTP, because it is too easy for attackers to intercept the SMS that contains the code.
 
 ## Operational Practices
 

--- a/docs/swag.html
+++ b/docs/swag.html
@@ -281,6 +281,26 @@ Insufficient access control and insecure exposure of object identifiers, such as
 - [Insecure Direct Object Reference Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html) (OWASP)
 - [Insecure Direct Object Reference (IDOR)](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/IDOR) (MDN)
 
+## Authentication guidelines
+
+This section outline guidelines for websites that need to authenticate users.
+
+We recommend that websites should use [passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) to authenticate users wherever possible. If you need to support other methods such as [one-time passwords (OTP)](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP) or [passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords), there are practices you can follow to minimise the risks.
+
+### Use passkeys to authenticate users
+
+Websites should support [passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) as an authentication mechanism. If you also support other methods such as passwords, encourage users to prefer passkeys, and enable users to [switch from passwords to passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys#migrating_from_passwords).
+
+Passkeys provide protection against many common attacks on authentication systems, including [phishing](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Phishing) attacks.
+
+### Follow good practices for OTP authentication
+
+Enable users to use [passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) to authenticate themselves to your site.
+
+### Follow good practices for password-based authentication
+
+We don't recommend that websites offer passwords as an authentication method,
+
 ## Operational Practices
 
 This section recommends operational practices. For example, how to make decisions about your architecture or dependencies, or which tools and policies to adapt.

--- a/docs/swag.html
+++ b/docs/swag.html
@@ -285,7 +285,7 @@ Insufficient access control and insecure exposure of object identifiers, such as
 
 This section outlines guidelines for websites that need to authenticate users.
 
-We recommend that websites should use [passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) to authenticate users wherever possible. If you need to support other methods such as [one-time passwords (OTP)](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP) or [passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords), there are practices you can follow to minimise the risks.
+We recommend that websites should use [passkeys](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passkeys) to authenticate users wherever possible. If you need to support other methods such as [one-time passwords (OTP)](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/OTP) or [passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords), there are practices you can follow to minimize the risks.
 
 ### Support passkeys
 

--- a/docs/swag.html
+++ b/docs/swag.html
@@ -308,7 +308,7 @@ Implementations should use reputable packages for verifying the assertions that 
 
 ### Follow good practices for password-based authentication
 
-Passwords have [several well-known security weaknesses](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#weaknesses_of_password-based_authentication), which are commonly exploited by attackers, so we don't recommend that websites offer passwords as an authentication method. If you do need to support them, there are some practices you can follow to minimise the risks:
+Passwords have [several well-known security weaknesses](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#weaknesses_of_password-based_authentication), which are commonly exploited by attackers, so we don't recommend that websites offer passwords as an authentication method. If you do need to support them, there are some practices you can follow to minimize the risks:
 
 - [Ensure that password managers can work with your site.](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#supporting_password_managers)
 - When users create new passwords, [check their strength and reject weak passwords](https://developer.mozilla.org/en-US/docs/Web/Security/Authentication/Passwords#choosing_strong_passwords).


### PR DESCRIPTION
This PR adds authentication guidelines. The general idea is:
- use passkeys if you can
- don't use passwords, but if you do, adding OTP as a second factor helps
- if you use OTP, use TOTP

I worry a bit that we're too keen on passkeys, I know some people think there are lock-in issues with them and I can see that.

At the moment all the links are to our own docs. It would be nice to link to other sources too. Maybe https://thecopenhagenbook.com/ ?

Fixes https://github.com/w3c-cg/swag/issues/32.